### PR TITLE
Call disconnectFromHost to emit TLS closure alert

### DIFF
--- a/commondir.pri
+++ b/commondir.pri
@@ -30,3 +30,7 @@ LIBS        += -L$$PRJDIR/xbin
 
 INCLUDEPATH +=  . $$PRJDIR/include $$PRJDIR/3rdparty
 
+equals(QT_MAJOR_VERSION, 5):lessThan(QT_MINOR_VERSION, 4) {
+  CONFIG -= c++11 c++14
+  QMAKE_CXXFLAGS += -std=c++14
+}

--- a/src/private/qsocket.hpp
+++ b/src/private/qsocket.hpp
@@ -28,8 +28,10 @@ class QSocket
 {
 public:
     void close() {
-        if ( itcpSocket )
+        if ( itcpSocket ) {
+            itcpSocket->disconnectFromHost();
             itcpSocket->close();
+        }
 
         if ( ilocalSocket )
             ilocalSocket->close();

--- a/src/qhttpsslsocket.cpp
+++ b/src/qhttpsslsocket.cpp
@@ -16,7 +16,10 @@ appendTrusted(QSslConfiguration& sslconfig, const CertificateList& cas) {
 
     auto trusted = cas;
     trusted << sslconfig.caCertificates()
-            << QSslConfiguration::systemCaCertificates();
+#if QT_VERSION >= 0x050500
+            << QSslConfiguration::systemCaCertificates()
+#endif
+    ;
     sslconfig.setCaCertificates(trusted);
 
     return true;


### PR DESCRIPTION
Call disconnectFromHost at end of a connection so that eventually SSL_shutdown is called on TLS connections to emit the TLS closure alert as required by the TLS specifications.