### PR TITLE
Fix Host header always containing port 65535 when URI does not contain explicit port

### DIFF
--- a/src/qhttpclientrequest.cpp
+++ b/src/qhttpclientrequest.cpp
@@ -78,13 +78,12 @@ void
 QHttpRequestPrivate::prepareHeadersToWrite() {
 
     if ( !iheaders.contains("host") ) {
-        quint16 port = iurl.port();
-        if ( port == 0 )
-            port = 80;
+        QString portStr = ( -1 != iurl.port() ) ?
+                          QString(":%1").arg(iurl.port()) : "";
 
         iheaders.insert("host",
-                        QString("%1:%2").arg(iurl.host()).arg(port).toLatin1()
-                        );
+                        QString("%1%2").arg(iurl.host()).arg(portStr).toLatin1()
+        );
     }
 }
 


### PR DESCRIPTION
The port number inside the `Host` header is always `USHRT_MAX` (i.e., 65535) when no explicit port was set in the URL. This causes many webservers to return the wrong website (or a 404 response therefore) when they manage multiple name-based virtual hosts.

This patch handles URLs without explicit port correctly and does not add any explicit port number to the `Host` header when the URL also contains none. I chose not to set any explicit port in that case, because an explicit port 80 (or 443) can also cause trouble with virtual hosts.